### PR TITLE
Receives values as String list only.

### DIFF
--- a/lib/exnumerable.ex
+++ b/lib/exnumerable.ex
@@ -2,19 +2,17 @@ defmodule Exnumerator do
   defmacro __using__(opts) do
     quote location: :keep, bind_quoted: [values: opts[:values]] do
       @behaviour Ecto.Type
-
+      
       def type,   do: :string
       def values, do: unquote(values)
       def sample, do: unquote(values) |> Enum.random
 
-      for value <- values, atom = value, string = Atom.to_string(value) do
-        def cast(unquote(string)), do: {:ok, unquote(atom)}
-        def cast(unquote(atom)),   do: {:ok, unquote(atom)}
-        def load(unquote(string)), do: {:ok, unquote(atom)}
-        def dump(unquote(string)), do: {:ok, unquote(string)}
-        def dump(unquote(atom)),   do: {:ok, unquote(string)}
+      for value <- values do
+        def cast(unquote(value)), do: {:ok, unquote(value)}
+        def load(unquote(value)), do: {:ok, unquote(value)}
+        def dump(unquote(value)), do: {:ok, unquote(value)}
       end
-
+      
       def cast(_), do: :error
       def load(_), do: :error
       def dump(_), do: :error

--- a/lib/exnumerable.ex
+++ b/lib/exnumerable.ex
@@ -2,7 +2,7 @@ defmodule Exnumerator do
   defmacro __using__(opts) do
     quote location: :keep, bind_quoted: [values: opts[:values]] do
       @behaviour Ecto.Type
-      
+
       def type,   do: :string
       def values, do: unquote(values)
       def sample, do: unquote(values) |> Enum.random
@@ -12,7 +12,7 @@ defmodule Exnumerator do
         def load(unquote(value)), do: {:ok, unquote(value)}
         def dump(unquote(value)), do: {:ok, unquote(value)}
       end
-      
+
       def cast(_), do: :error
       def load(_), do: :error
       def dump(_), do: :error

--- a/test/exnumerable_test.exs
+++ b/test/exnumerable_test.exs
@@ -18,14 +18,14 @@ defmodule ExnumeratorTest do
     assert Message.cast("sent")      == {:ok, "sent"}
     assert Message.load("received")  == {:ok, "received"}
     assert Message.dump("delivered") == {:ok, "delivered"}
-    assert Message.cast(:sent)       == :error
-    assert Message.load(:received)   == :error
-    assert Message.dump(:delivered)  == :error
   end
 
   test "should not cast unknown argument" do
     assert Message.cast("invalid") == :error
     assert Message.load("invalid") == :error
     assert Message.dump("invalid") == :error
+    assert Message.cast(:invalid)  == :error
+    assert Message.load(:invalid)  == :error
+    assert Message.dump(:invalid)  == :error
   end
 end

--- a/test/exnumerable_test.exs
+++ b/test/exnumerable_test.exs
@@ -1,11 +1,11 @@
 defmodule ExnumeratorTest do
   use ExUnit.Case
 
-  @values [:sent, :read, :received, :delivered]
+  @values ["sent", "read", "received", "delivered"]
 
   defmodule Message do
     use Exnumerator,
-      values: [:sent, :read, :received, :delivered]
+      values: ["sent", "read", "received", "delivered"]
   end
 
   test "should store given values",
@@ -14,20 +14,18 @@ defmodule ExnumeratorTest do
   test "should return a random value",
     do: assert Message.sample in @values
 
-  test "should augment given types" do
-    assert Message.cast("sent")      == {:ok, :sent}
-    assert Message.cast(:read)       == {:ok, :read}
-    assert Message.load("received")  == {:ok, :received}
+  test "should argument given types" do
+    assert Message.cast("sent")      == {:ok, "sent"}
+    assert Message.load("received")  == {:ok, "received"}
     assert Message.dump("delivered") == {:ok, "delivered"}
-    assert Message.dump(:sent)       == {:ok, "sent"}
+    assert Message.cast(:sent)       == :error
+    assert Message.load(:received)   == :error
+    assert Message.dump(:delivered)  == :error
   end
 
   test "should not cast unknown argument" do
     assert Message.cast("invalid") == :error
-    assert Message.cast(:invalid)  == :error
     assert Message.load("invalid") == :error
-    assert Message.load(:invalid)  == :error
     assert Message.dump("invalid") == :error
-    assert Message.dump(:invalid)  == :error
   end
 end

--- a/test/exnumerable_test.exs
+++ b/test/exnumerable_test.exs
@@ -20,6 +20,12 @@ defmodule ExnumeratorTest do
     assert Message.dump("delivered") == {:ok, "delivered"}
   end
 
+  test "should not accept argument except string" do
+    assert Message.cast(:sent)     == :error
+    assert Message.load(:sent)     == :error
+    assert Message.dump(:sent)     == :error
+  end
+
   test "should not cast unknown argument" do
     assert Message.cast("invalid") == :error
     assert Message.load("invalid") == :error


### PR DESCRIPTION
I've recognized that your original codes are intended to receive values as either atoms or strings.

But unfortunately the string values produce failure on Atom.to_string/1, so there are two remedies;
1) Cast atom to string selectively in the module using Enum.map/2.
2) Receive values as a string list only. (Developers will be forced not to use atom type)

At first I chose 1), but practically there's no advantages to use non-GCed atom type more than necessary. So I condensed this exnumerator to put more simple to use on.