### PR TITLE
Bump to 1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This project is helpful if you have both [`ecto`](https://github.com/elixir-lang
 ```elixir
 defmodule MyProject.Message.Status do
   use Exnumerator,
-    values: [:sent, :read, :received, :delivered]
+    values: ["sent", "read", "received", "delivered"]
 end
 ```
 
@@ -86,7 +86,7 @@ end
 
 ```elixir
 iex(1)> MyProject.Message.Status.values
-[:sent, :read, :received, :delivered]
+["sent", "read", "received", "delivered"]
 ```
 
 When you try to insert a record with some value that is not defined, you will get the following error:
@@ -101,7 +101,7 @@ iex(1)> %MyProject.Message{status: "invalid"} |> MyProject.Repo.insert!
 
 ```elixir
 iex(1)> MyProject.Message.Status.sample
-:delivered
+"delivered"
 ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The package can be installed as:
 
 ```elixir
 def deps do
-  [{:exnumerator, "~> 1.2.1"}]
+  [{:exnumerator, "~> 1.3.0"}]
 end
 ```
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Exnumerator.Mixfile do
   def project do
     [
       app:             :exnumerator,
-      version:         "1.2.2",
+      version:         "1.3.0",
       elixir:          "~> 1.5",
       build_embedded:  Mix.env == :prod,
       start_permanent: Mix.env == :prod,


### PR DESCRIPTION
Two things are changed;
1) Version bumped to 1.3.0 from 1.2.2, which is indicating breaking changes.
2) Readme updated to use string type instead of atoms.